### PR TITLE
Create pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,20 @@
+### Description
+
+Please Include a short summary of your Pull Request.
+
+### Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+### Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] There are no hardcoded strings
+- [ ] I have reviewed my code and guarantee that the code is not Plagiarised


### PR DESCRIPTION
This PR is in context to issue #60 
To make PR template hidden, just add ```.github/``` before the path of pull_request_template.md