### PR TITLE
Add pre-deploy script to persist database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ cache: bundler # caching bundler gem packages will speed up build
 notifications:
   email: false
 
+before_deploy:
+  - mkdir planet_db
+  - cp planet.db planet_db/planet.db
+
 deploy:
   - local-dir: out/
     provider: pages


### PR DESCRIPTION
Critical for master branch builds in order to persist information.