### PR TITLE
head.html: remove author names meta tag

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -4,7 +4,6 @@
   <title> {% if page.title %}{{page.title}} | {% endif %}{{site.title}} | IIIT-Delhi </title>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="author" content="{{site.author}}">
   <meta name="description" content="{{site.description}}">
   <meta name="keywords" content="{{site.keywords}}">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
It's used in link previews and that's possibly interpreting it as a blog post author, giving it a very prominent spot right below the title.